### PR TITLE
Add components for powering bias on/off

### DIFF
--- a/xicam/Acquire/controllers/fastccd_controller.py
+++ b/xicam/Acquire/controllers/fastccd_controller.py
@@ -39,6 +39,18 @@ class FastCCDController(AreaDetectorController):
         auto_start.setText('Auto Start')
         camera_layout.addWidget(auto_start)
 
+        bias_layout = QVBoxLayout()
+        bias_panel = QGroupBox('BIAS State')
+        bias_panel.setLayout(bias_layout)
+
+        bias_layout.addWidget(PyDMLabel(init_channel=f'ca://{device.cam.bias_state.pvname}'))
+        bias_layout.addWidget(
+            PyDMPushButton(pressValue=1, init_channel=f'ca://{device.cam.bias_on.pvname}', label='Power On')
+        )
+        bias_layout.addWidget(
+            PyDMPushButton(pressValue=1, init_channel=f'ca://{device.cam.bias_off.pvname}', label='Power Off')
+        )
+
         dg_layout = QHBoxLayout()
         dg_panel = QGroupBox('Delay Gen State')
         dg_panel.setLayout(dg_layout)
@@ -70,6 +82,7 @@ class FastCCDController(AreaDetectorController):
         )
 
         self.hlayout.addWidget(camera_panel)
+        self.hlayout.addWidget(bias_panel)
         self.hlayout.addWidget(dg_panel)
         self.passive.setVisible(False)  # active mode is useless for fastccd at COSMIC-Scattering
 

--- a/xicam/Acquire/devices/fastccd.py
+++ b/xicam/Acquire/devices/fastccd.py
@@ -330,6 +330,10 @@ class FCCDCam(AreaDetectorCam):
 
     error_status = ADCpt(EpicsSignalRO, "ErrorStatus")
 
+    bias_state = ADCpt(EpicsSignal, "BiasState")
+    bias_on = ADCpt(EpicsSignal, "BiasOn")
+    bias_off = ADCpt(EpicsSignal, "BiasOff")
+
     def __init__(self, *args, temp_pv=None, **kwargs):
         self._temp_pv = temp_pv
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
- [ ] Requires that the `fastccd_support_ioc` [bias_state](https://github.com/lbl-camera/fastccd_support_ioc/pull/6) branch is merged into the `fastccd_support_ioc` `ibterm_lock` branch